### PR TITLE
feat: support partitionKey in cookies status

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ interface AddonApi {
   cookiesStatus(params: {
     url?: string;
     domain?: string;
+    partitionKey?: browser.cookies.CookiePartitionKey;
     keys: string[] | '*';
   }): Promise<Record<string, CookieStatus>>;
 

--- a/src/rpc/types.ts
+++ b/src/rpc/types.ts
@@ -225,6 +225,7 @@ export type ClientCmd = {
     params: {
       url?: string;
       domain?: string;
+      partitionKey?: Browser.cookies.CookiePartitionKey;
       keys: string[] | "*";
     },
     env: EnvType,

--- a/src/utils/api.ts
+++ b/src/utils/api.ts
@@ -194,8 +194,8 @@ export async function cookies_getStr(url: string): Promise<string> {
 export async function cookies_status(
   params: Parameters<ClientCmd["cookies.status"]>[0],
 ): Promise<Record<string, CookieStatus | null>> {
-  const { url, domain, keys } = params;
-  const cookies = await browser.cookies.getAll({ url, domain });
+  const { url, domain, partitionKey, keys } = params;
+  const cookies = await browser.cookies.getAll({ url, domain, partitionKey });
   const ret: Awaited<ReturnType<ClientCmd["cookies.status"]>> = {};
   if (keys === "*") {
     for (const cookie of cookies) {


### PR DESCRIPTION
Cloudflare 的 cf_clearance 在部分场景下会被 Chrome 以 Partitioned Cookie（CHIPS）的形式存储。
之前插件调用 cookies.get/getAll 时没有指定 partitionKey，导致部分站点无法正确获取 cf_clearance。
此 PR 为 Cookie 查询增加了 partitionKey 支持。